### PR TITLE
Total Points Counter 

### DIFF
--- a/main.py
+++ b/main.py
@@ -224,7 +224,51 @@ async def on_message(message):
                         pilots_obj["name"] += f"({pilots_obj['cost']})"
                         return pilots_obj["name"]
         return None
+    
+    def get_gamemode(yasb_url: str) -> tuple[str,int]: #TODO remember type hint for "Or None"
+        """Very quick and dirty method to extract game mode of built squad
+        
 
+        Args:
+            yasb_url (str): original url of squad from xwing-legacy.com
+
+        Returns:
+            tuple[str,int]: Game mode information (Game mode name, Total points)
+                            Returns None if extraction fails 
+        """
+
+        MODE_MAPPING = {
+            "s": "Standard",
+            "h": "Wildspace",
+            "e": "Epic",
+            "q": "Quickbuild"
+        }
+
+        # Very dirty, will need modified if squadbuilder changes url format
+        MODE_CHAR_LOC = 6
+        TOTAL_POINTS_SLICE_START = 8
+        TOTAL_POINTS_SLICE_END = -1
+
+        # Extract mode and points total from url
+        url_mode_pattern = re.compile(
+            r"&d=v8Z[sheq]Z\d*Z"
+        )
+        mode_match = url_mode_pattern.search(yasb_url)
+        mode_indicator = mode_match.group()
+        
+        try: 
+            return ( 
+            MODE_MAPPING[mode_indicator[MODE_CHAR_LOC]],
+            int(mode_indicator[TOTAL_POINTS_SLICE_START,
+                               TOTAL_POINTS_SLICE_END]) 
+            ) 
+        
+        except ValueError as e:
+            return #Failure of integer conversion implies URL format is off 
+
+        
+        
+        
     def get_squad_list(xws_dict, upgrades_dir, faction_pilots_dir):
         """Get yasb link and convert it to readable embed.
 

--- a/main.py
+++ b/main.py
@@ -265,9 +265,6 @@ async def on_message(message):
         
         except ValueError as e:
             return #Failure of integer conversion implies URL format is off 
-
-        
-        
         
     def get_squad_list(xws_dict, upgrades_dir, faction_pilots_dir):
         """Get yasb link and convert it to readable embed.
@@ -280,13 +277,20 @@ async def on_message(message):
         Returns:
             str: multiline string of pilots and upgrades
         """
+        # Note gamemode string currently unused
+        game_mode = get_gamemode(xws_dict["vendor"]["yasb"]["link"])
+
+        # Meta details header
         squad_list = ""
         squad_list += (
             convert_xws(str(xws_dict["faction"]))
             + " ["
             + str(xws_dict["points"])
-            + "]\n"
         )
+        if game_mode:
+            squad_list += ("/" + str(game_mode[1]))
+        squad_list += "]\n"
+        
         # Check if pilots is a list and iterate throught pilots
         if "pilots" in xws_dict and isinstance(
             xws_dict["pilots"], list

--- a/main.py
+++ b/main.py
@@ -259,7 +259,7 @@ async def on_message(message):
         try: 
             return ( 
             MODE_MAPPING[mode_indicator[MODE_CHAR_LOC]],
-            int(mode_indicator[TOTAL_POINTS_SLICE_START,
+            int(mode_indicator[TOTAL_POINTS_SLICE_START:
                                TOTAL_POINTS_SLICE_END]) 
             ) 
         


### PR DESCRIPTION
Added a quick implementation of a function `get_gamemode` to extract the game mode (and associated total allowed points) under which a squad is built.

Used this to add a denominator to the total points embed, allowing bid to be glimpsed slightly easier.
Will allow for the bid to be easily computed and added to the embed by someone more familiar with how it is laid out. 

Each individual function has been tested in an independent offline environment, but a complete deployment test has not been undertaken.